### PR TITLE
added pino to package.json for out-of-the-box npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "ISC",
   "dependencies": {
     "@adiwajshing/baileys": "^4.4.0",
+    "pino": "^8.7.0",
     "qrcode-terminal": "^0.12.0",
     "uint8-to-base64": "^0.2.0"
   }


### PR DESCRIPTION
The `pino` dependency wasn't mentioned in the `package.json` file yet, so running `npm install` (or with any other package manager like `pnpm` oder `bun` (I love their package manager and bun in general <3)) wouldn't run and install everything "out of the box". Not dramatic though!